### PR TITLE
Handle info support

### DIFF
--- a/src/Pinto/Gen.purs
+++ b/src/Pinto/Gen.purs
@@ -7,6 +7,8 @@ module Pinto.Gen ( startLink
                  , doCall
                  , cast
                  , doCast
+                 , defaultHandleInfo
+                 , registerExternalMapping
                  ) 
   where
 
@@ -15,12 +17,14 @@ import Prelude
 import Effect (Effect)
 import Erl.Atom (Atom, atom)
 import Pinto (ServerName(..), StartLinkResult)
+import Data.Maybe (Maybe(..))
 
 foreign import callImpl :: forall response state. Atom -> (state -> (CallResult response state)) -> Effect response
 foreign import doCallImpl :: forall response state. Atom -> (state -> Effect (CallResult response state)) -> Effect response
 foreign import castImpl :: forall state. Atom -> (state -> (CastResult state)) -> Effect Unit
 foreign import doCastImpl :: forall state. Atom -> (state -> Effect (CastResult state)) -> Effect Unit
-foreign import startLinkImpl :: forall state. Atom -> Effect state -> Effect StartLinkResult
+foreign import startLinkImpl :: forall state msg. Atom -> Effect state -> (msg -> state -> Effect state) -> Effect StartLinkResult
+foreign import registerExternalMappingImpl :: forall state externalMsg msg. Atom -> (externalMsg -> Maybe msg) -> Effect Unit
 
 -- These imports are just so we don't get warnings
 foreign import code_change :: forall a. a -> a -> a -> a
@@ -31,25 +35,35 @@ foreign import init :: forall a. a -> a
 foreign import terminate :: forall a. a -> a -> a
 foreign import start_from_spec :: forall a. a -> a
 
+
+-- | Adds a (presumably) native Erlang function into the gen server to map external messages into types that this
+-- | gen server actually understands
+registerExternalMapping :: forall state externalMsg msg. ServerName state msg -> (externalMsg -> Maybe msg) -> Effect Unit
+registerExternalMapping (ServerName name) = registerExternalMappingImpl (atom name)
+
+
 -- | Starts a typed gen-server proxy with the supplied ServerName, with the state being the result of the supplied effect
 -- |
 -- | ```purescript
--- | serverName :: ServerName State
+-- | serverName :: ServerName State Unit
 -- | serverName = ServerName "some_uuid"
 -- | 
--- | startLink :: Effect StartLinkResults
--- | startLink = Gen.startLink serverName init
+-- | startLink :: Effect StartLinkResult
+-- | startLink = Gen.startLink serverName init defaultHandleInfo
 -- | 
 -- | init :: Effect State
 -- | init = pure {}
 -- | ```
--- | See also: gen_server:start_link in the OTP docs
-startLink :: forall state. ServerName state -> Effect state -> Effect StartLinkResult
-startLink (ServerName name) eff =
-  startLinkImpl (atom name) eff
+-- | See also: gen_server:start_link in the OTP docs (roughly)
+startLink :: forall state msg. ServerName state msg -> Effect state -> (msg -> state -> Effect state) -> Effect StartLinkResult
+startLink (ServerName name) = startLinkImpl (atom name)
 
 data CallResult response state = CallReply response state | CallReplyHibernate response state | CallStop response state
 data CastResult state = CastNoReply state | CastNoReplyHibernate state | CastStop state
+
+-- | A default implementation of handleInfo that just ignores any messages received
+defaultHandleInfo :: forall state msg. msg -> state -> Effect state
+defaultHandleInfo msg state = pure state
 
 -- | Defines a "pure" "call" that performs an interaction on the state held by the gen server, but with no other side effects
 -- | Directly returns the result of the callback provided
@@ -59,7 +73,7 @@ data CastResult state = CastNoReply state | CastNoReplyHibernate state | CastSto
 -- | doSomething = Gen.call serverName \state -> CallReply unit (modifyState state)
 -- | ```
 -- | See also handle_call and gen_server:call in the OTP docs
-call :: forall response state. ServerName state -> (state -> (CallResult response state)) -> Effect response
+call :: forall response state msg. ServerName state msg -> (state -> (CallResult response state)) -> Effect response
 call (ServerName name) fn = callImpl (atom name) fn
 
 -- | Defines an effectful call that performs an interaction on the state held by the gen server, and perhaps side-effects
@@ -70,7 +84,7 @@ call (ServerName name) fn = callImpl (atom name) fn
 -- | doSomething = Gen.doCall serverName \state -> pure $ CallReply unit (modifyState state)
 -- | ```
 -- | See also handle_call and gen_server:call in the OTP docs
-doCall :: forall response state. ServerName state -> (state -> Effect (CallResult response state)) -> Effect response
+doCall :: forall response state msg. ServerName state msg -> (state -> Effect (CallResult response state)) -> Effect response
 doCall (ServerName name) fn = doCallImpl (atom name) fn
 
 -- | Defines an "pure" cast that performs an interaction on the state held by the gen server
@@ -79,7 +93,7 @@ doCall (ServerName name) fn = doCallImpl (atom name) fn
 -- | doSomething = Gen.cast serverName \state -> CastNoReply $ modifyState state
 -- | ```
 -- | See also handle_cast and gen_server:cast in the OTP docs
-cast :: forall state. ServerName state -> (state -> (CastResult state)) -> Effect Unit
+cast :: forall state msg. ServerName state msg -> (state -> (CastResult state)) -> Effect Unit
 cast (ServerName name) fn = castImpl (atom name) fn
 
 -- | Defines an effectful cast that performs an interaction on the state held by the gen server
@@ -88,5 +102,5 @@ cast (ServerName name) fn = castImpl (atom name) fn
 -- | doSomething = Gen.cast serverName \state -> pure $ CastNoReply $ modifyState state
 -- | ```
 -- | See also handle_cast and gen_server:cast in the OTP docs
-doCast :: forall state. ServerName state -> (state -> Effect (CastResult state)) -> Effect Unit
+doCast :: forall state msg. ServerName state msg -> (state -> Effect (CastResult state)) -> Effect Unit
 doCast (ServerName name) fn = doCastImpl (atom name) fn

--- a/src/Pinto/Sup.erl
+++ b/src/Pinto/Sup.erl
@@ -17,7 +17,7 @@ startLinkImpl(Name, Effect) ->
 
 startChildImpl(AlreadyStarted, Started, Name, Args) ->
   fun() ->
-    case supervisor:start_child(Name, Args) of
+    case supervisor:start_child(Name, [Args]) of
       {error, {already_started, Pid}} -> AlreadyStarted(Pid);
       { ok, Pid } -> Started(Pid)
     end

--- a/src/Pinto/Sup.purs
+++ b/src/Pinto/Sup.purs
@@ -82,8 +82,8 @@ startLink name spec = startLinkImpl (atom name) spec
 -- | Note: This API is subject to change, as it is "handwavingly" typed and currently maps 1-1 with the 
 -- | native Erlang implementation
 -- | See also: supervisor:start_child in the OTP docs
-startChild :: String -> SupervisorChildSpec -> Effect Pinto.StartChildResult
-startChild name childSpec = startChildImpl Pinto.AlreadyStarted Pinto.Started (atom name) (reifySupervisorChild childSpec)
+startChild :: forall args. String -> args -> Effect Pinto.StartChildResult
+startChild name args = startChildImpl Pinto.AlreadyStarted Pinto.Started (atom name) args
 
 -- | See also supervisor:strategy()
 -- | Maps to simple_one_for_one | one_for_one .. etc

--- a/src/Pinto/Timer.erl
+++ b/src/Pinto/Timer.erl
@@ -4,43 +4,21 @@
           sendEvery_/3,
           sendAfter_/3 ]).
 
-cancel_(Pid) ->
+cancel_(Ref) ->
   fun() ->
-      Pid ! stop,
-      ok
+    timer:cancel(Ref)
   end.
 
-%% Note: The actual timer implementation deliberately avoids using processes for
-%% this sort of thing because it means needlessly exhauting the process pool
-%% so a cleverer solution will probably be needed in time
-sendEvery_(Wrapper, Milliseconds, Effect) ->
-  Fun = fun Fun(MaybeRef) ->
-            { ok, Ref } = case MaybeRef of
-                            undefined -> timer:send_interval(Milliseconds, tick);
-                            _ -> {  ok, MaybeRef }
-                          end,
-            receive
-              stop ->
-                io:format(user, "Shutting down timer cos parent died", []),
-                timer:cancel(Ref);
-              tick ->
-                Effect(),
-                Fun(Ref)
-            end
-        end,
-  fun() -> Pid = spawn_link(fun() -> Fun(undefined) end), Wrapper(Pid) end.
+%% Sod it, simple
+sendEvery_(Wrapper, Milliseconds, Msg) ->
+  fun() ->
+    { ok, Ref } = timer:send_interval(Milliseconds, Msg),
+    Wrapper(Ref)
+  end.
 
-sendAfter_(Wrapper, Milliseconds, Effect) ->
-  _Parent = self(),
-  Fun = fun Fun() ->
-            { ok, Ref } = timer:send_after(Milliseconds, tick),
-            receive
-              stop ->
-                timer:cancel(Ref);
-              tick ->
-                Effect();
-              Other ->
-                io:format(user, "Wtf ~p~n", [ Other])
-            end
-        end,
-  fun() -> Pid = spawn_link(fun() -> Fun() end), Wrapper(Pid) end.
+%% Ditto
+sendAfter_(Wrapper, Milliseconds, Msg) ->
+  fun() ->
+    { ok, Ref } = timer:send_after(Milliseconds, Msg),
+    Wrapper(Ref)
+  end.

--- a/src/Pinto/Timer.purs
+++ b/src/Pinto/Timer.purs
@@ -15,19 +15,19 @@ import Pinto (ServerName)
 
 newtype TimerRef = TimerRef Pid
 
-foreign import sendEvery_ :: forall msg. (Pid -> TimerRef) -> Int -> msg -> Effect TimerRef
-foreign import sendAfter_ :: forall msg. (Pid -> TimerRef) -> Int -> msg -> Effect TimerRef
+foreign import sendEvery_ :: forall msg.  (Pid -> TimerRef) -> Int -> msg -> Effect TimerRef
+foreign import sendAfter_ :: forall msg.  (Pid -> TimerRef) -> Int -> msg -> Effect TimerRef
 foreign import cancel_ :: Pid -> Effect Unit
 
 -- | Sends the supplied message back to the recipient every N milliseconds
 -- | See also timer:send_every in the OTP docs
-sendEvery :: forall msg. Int -> msg -> Effect TimerRef
-sendEvery = sendEvery_ TimerRef
+sendEvery :: forall state msg. ServerName state msg -> Int -> msg -> Effect TimerRef
+sendEvery _ = sendEvery_ TimerRef
 
 -- | Sends the supplied message back to the recipient after N milliseconds
 -- | See also timer:send_after in the OTP docs
-sendAfter :: forall msg. Int -> msg -> Effect TimerRef
-sendAfter = sendAfter_ TimerRef
+sendAfter :: forall state msg. ServerName state msg -> Int -> msg -> Effect TimerRef
+sendAfter _ = sendAfter_ TimerRef
 
 -- | Cancels a timer started by either sendEvery or sendAfter
 -- | See also timer:cancel in the OTP docs

--- a/src/Pinto/Timer.purs
+++ b/src/Pinto/Timer.purs
@@ -1,5 +1,5 @@
 -- | This module provides a means of using the timer functionality in core Erlang
--- | This is subject to change as currently it only works within the context of a genserver
+-- | This is specifically for use within the context of gen-servers and will not work otherwise
 module Pinto.Timer 
   ( sendEvery,
     sendAfter,
@@ -15,20 +15,18 @@ import Pinto (ServerName)
 
 newtype TimerRef = TimerRef Pid
 
-foreign import sendEvery_ :: (Pid -> TimerRef) -> Int -> Effect Unit -> Effect TimerRef
-foreign import sendAfter_ :: (Pid -> TimerRef) -> Int -> Effect Unit -> Effect TimerRef
+foreign import sendEvery_ :: forall msg. (Pid -> TimerRef) -> Int -> msg -> Effect TimerRef
+foreign import sendAfter_ :: forall msg. (Pid -> TimerRef) -> Int -> msg -> Effect TimerRef
 foreign import cancel_ :: Pid -> Effect Unit
 
--- | Invokes the supplied effect every N milliseconds 
+-- | Sends the supplied message back to the recipient every N milliseconds
 -- | See also timer:send_every in the OTP docs
--- | The process started by this will automatically terminate when the parent process dies
-sendEvery :: forall state. Int -> Effect Unit -> Effect TimerRef
+sendEvery :: forall msg. Int -> msg -> Effect TimerRef
 sendEvery = sendEvery_ TimerRef
 
--- | Invokes the supplied effect after N milliseconds 
--- | See also timer:send_every in the OTP docs
--- | The process started by this will automatically terminate when the parent process dies
-sendAfter :: forall state. Int -> Effect Unit -> Effect TimerRef
+-- | Sends the supplied message back to the recipient after N milliseconds
+-- | See also timer:send_after in the OTP docs
+sendAfter :: forall msg. Int -> msg -> Effect TimerRef
 sendAfter = sendAfter_ TimerRef
 
 -- | Cancels a timer started by either sendEvery or sendAfter

--- a/src/Pinto/Types.purs
+++ b/src/Pinto/Types.purs
@@ -5,9 +5,10 @@ import Erl.Data.Tuple (Tuple2)
 import Erl.Process.Raw (Pid)
 
 -- | Defines the server name for a gen server, along with the 'state' that the gen server
--- | will be using internally - this will be supplied to every call to the gen server API in order
+-- | will be using internally and the 'msg' type that will be received in the handleInfo calls
+-- | this will be supplied to every call to the gen server API in order
 -- | to enforce type safety across calls
-data ServerName state = ServerName String
+data ServerName state msg = ServerName String
 
 -- | The result of invoking gen_server:start_link
 type StartLinkResult = (Tuple2 Atom Pid)


### PR DESCRIPTION
No more pesky child processes for timers/external messages, just pass in mappers for native erlang types and cross your fingers.